### PR TITLE
Change action bar layout to have action-bar-title

### DIFF
--- a/blank/blank-page.xml
+++ b/blank/blank-page.xml
@@ -1,5 +1,6 @@
 <Page navigatingTo="onNavigatingTo" class="page" xmlns="http://schemas.nativescript.org/tns.xsd">
-    <ActionBar title="Home" class="action-bar">
+    <ActionBar class="action-bar">
+        <Label class="action-bar-title" text="Home"></Label>
     </ActionBar>
 
     <StackLayout>

--- a/login/login-page.xml
+++ b/login/login-page.xml
@@ -1,5 +1,6 @@
 <Page navigatingTo="onNavigatingTo" class="page" xmlns="http://schemas.nativescript.org/tns.xsd">
-    <ActionBar title="Login" class="action-bar">
+    <ActionBar class="action-bar">
+        <Label class="action-bar-title" text="Login"></Label>
     </ActionBar>
 
     <StackLayout class="p-t-15">

--- a/signup/signup-page.xml
+++ b/signup/signup-page.xml
@@ -1,5 +1,6 @@
 <Page navigatingTo="onNavigatingTo" class="page" xmlns="http://schemas.nativescript.org/tns.xsd">
-    <ActionBar title="Sign up" icon="" class="action-bar">
+    <ActionBar icon="" class="action-bar">
+        <Label class="action-bar-title" text="Sign up"></Label>
     </ActionBar>
 
     <StackLayout class="p-t-15">


### PR DESCRIPTION
Change action bar layout to use the same layout as the other templates. In this way the page title will be always center. Otherwise once will be center, another time - left